### PR TITLE
Add runtime: false option on readme guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hex (shown at the top of this README).
 
 ```elixir
 def deps do
-  [{:unsafe, "~> 1.0"}]
+  [{:unsafe, "~> 1.0", runtime: false}]
 end
 ```
 


### PR DESCRIPTION
Since this package is used in compile time, it'd be better to explicitly exclude in run-time deps.

It'll also help `Distillery` to build release which deps to included.