### PR TITLE
Fixes for Elixir warnings

### DIFF
--- a/lib/unsafe/compiler.ex
+++ b/lib/unsafe/compiler.ex
@@ -111,9 +111,10 @@ defmodule Unsafe.Compiler do
   # Finally, if this definition fires, the provided definition
   # for the binding was totally invalid and should cause errors.
   def compile!(env, _invalid, _options),
-    do: raise CompileError, [
-      description: "Invalid function reference provided",
-      file: env.file,
-      line: env.line
-    ]
+    do:
+      raise(CompileError,
+        description: "Invalid function reference provided",
+        file: env.file,
+        line: env.line
+      )
 end

--- a/test/unsafe_test.exs
+++ b/test/unsafe_test.exs
@@ -108,5 +108,5 @@ defmodule UnsafeTest do
   end
 
   defp load_file(file),
-    do: Code.load_file("test/modules/#{file}.exs")
+    do: Code.require_file("test/modules/#{file}.exs")
 end


### PR DESCRIPTION
See:
- #5

* Added parenthesis around a `do:` target (backward compatible)
* Replace `Code.load_file` (deprecated) by `Code.require_file` (available since at least Elixir 1.10)

I did not commit changes in formatting, and wonder if you would welcome a formatting PR separately.